### PR TITLE
Alterar configuração de indentação do XML

### DIFF
--- a/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
+++ b/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
@@ -258,7 +258,7 @@ namespace Simansoft.SAFT.Mozambique.Generators
         {
             XmlWriterSettings settings = new()
             {
-                Indent = true,
+                Indent = false,
                 Encoding = Encoding.UTF8
             };
             //using StringWriter stringWriter = new();


### PR DESCRIPTION
Mudou a propriedade `Indent` de `true` para `false` na configuração do `XmlWriterSettings`. Isso resulta em uma saída XML mais compacta, sem indentação.