### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/block-invalid-merges-develop.yml
+++ b/.github/workflows/block-invalid-merges-develop.yml
@@ -1,4 +1,6 @@
 name: Prevenir Merges inválidos para o Develop
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/SimansoftMZ/SAF-T/security/code-scanning/3](https://github.com/SimansoftMZ/SAF-T/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only reads the branch name and does not require any write permissions, we will set `contents: read` as the minimal required permission. This ensures the workflow operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
