### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/saft-core-ci-cd.yml
+++ b/.github/workflows/saft-core-ci-cd.yml
@@ -2,6 +2,9 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: SAF-T.Core CI/CD
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SimansoftMZ/SAF-T/security/code-scanning/4](https://github.com/SimansoftMZ/SAF-T/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the following permissions are needed:
- `contents: read` for accessing repository contents during the build process.
- `packages: write` for publishing the NuGet package.

The `permissions` block will be added after the `name` field (line 4) to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
