### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/block-invalid-merges-release.yml
+++ b/.github/workflows/block-invalid-merges-release.yml
@@ -1,5 +1,8 @@
 name: Prevenir Merges inválidos para o Release
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/SimansoftMZ/SAF-T/security/code-scanning/8](https://github.com/SimansoftMZ/SAF-T/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only reads the `GITHUB_HEAD_REF` environment variable and does not perform any write operations, we will set `contents: read` as the minimal required permission. This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
