### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/saft-cryptography-ci-cd.yml
+++ b/.github/workflows/saft-cryptography-ci-cd.yml
@@ -2,6 +2,9 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: SAF-T.Cryptography CI/CD
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SimansoftMZ/SAF-T/security/code-scanning/5](https://github.com/SimansoftMZ/SAF-T/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: write` for publishing the NuGet package.

The `permissions` block will be added after the `name` key (line 4) to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
