### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/block-invalid-merges-main.yml
+++ b/.github/workflows/block-invalid-merges-main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check_source_branch:
     name: Prevenir Merges inválidos para o Main


### PR DESCRIPTION
Potential fix for [https://github.com/SimansoftMZ/SAF-T/security/code-scanning/7](https://github.com/SimansoftMZ/SAF-T/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since the workflow only reads the branch name and does not perform any write operations, we will set `contents: read` as the minimal permission. This ensures that the workflow has only the permissions it needs and mitigates potential security risks.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
