### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/saft-mozambique-ci-cd.yml
+++ b/.github/workflows/saft-mozambique-ci-cd.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: SAF-T.Mozambique CI/CD
+permissions:
+  contents: read
 
 on:
   push:
@@ -56,5 +58,7 @@ jobs:
         dotnet pack --configuration Release -p:PackageVersion=${PACKAGE_VERSION} --no-build -o ./nupkg
       
     - name: Publicar no NuGet
+      permissions:
+        packages: write
       run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_PUBLISH_KEY }}
     


### PR DESCRIPTION
Potential fix for [https://github.com/SimansoftMZ/SAF-T/security/code-scanning/6](https://github.com/SimansoftMZ/SAF-T/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the workflow. Most steps in the workflow only require `contents: read`, but the step that publishes to NuGet requires `packages: write`. We will set `contents: read` at the root level and override it with `packages: write` for the specific job that publishes to NuGet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
