### PR TITLE
Develop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,7 +81,7 @@ jobs:
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above
     # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
+    # to build your code .
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - if: matrix.build-mode == 'manual'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,8 +21,7 @@ on:
 
 jobs:
   analyze:
-    name: Analisar codigo
-    # name: Analyze (${{ matrix.language }})
+    name: Analisar (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,8 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analisar codigo
+    # name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
@@ -66,7 +67,7 @@ jobs:
     #   uses: actions/setup-example@v1
 
     # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
+    - name: Inicializar o CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
@@ -94,7 +95,7 @@ jobs:
         echo '  make release'
         exit 1
 
-    - name: Perform CodeQL Analysis
+    - name: Fazendo analises com o CodeQL
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop", "release-**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop", "release-**" ]
   schedule:
     - cron: '37 22 * * 5'
 

--- a/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
+++ b/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
@@ -258,7 +258,7 @@ namespace Simansoft.SAFT.Mozambique.Generators
         {
             XmlWriterSettings settings = new()
             {
-                Indent = true,
+                Indent = false,
                 Encoding = Encoding.UTF8
             };
             //using StringWriter stringWriter = new();


### PR DESCRIPTION
This pull request includes updates to the CodeQL workflow configuration and a minor adjustment in the Mozambique SAF-T generator. The most important changes involve expanding branch coverage for CodeQL analysis, translating workflow step names to Portuguese, and modifying XML writer settings for performance.

### Updates to CodeQL workflow configuration:
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L16-R24): Expanded branch coverage for triggering CodeQL analysis to include `develop` and `release-**` branches.
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L16-R24): Translated workflow step names to Portuguese, including "Analyze" to "Analisar," "Initialize CodeQL" to "Inicializar o CodeQL," and "Perform CodeQL Analysis" to "Fazendo analises com o CodeQL." [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L16-R24) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L69-R69) [[3]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L97-R97)

### Adjustment in Mozambique SAF-T generator:
* [`src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs`](diffhunk://#diff-728e454a4d7793f0002503cddffe8040fa152c24e08b0c62eede93aaef6a3d91L261-R261): Changed `XmlWriterSettings.Indent` from `true` to `false` to potentially improve performance by disabling XML indentation.