### PR TITLE
Aprimora geração de XML e remove JSON e endereços

### DIFF
--- a/samples/SAF-T.Examples/MozambiqueDemo/BasicMozDemo.cs
+++ b/samples/SAF-T.Examples/MozambiqueDemo/BasicMozDemo.cs
@@ -34,7 +34,7 @@ namespace Simansoft.SAFT.Examples.MozambiqueDemo
 
             // Serialize para JSON (mas com estrutura XML)
             //var json = gerador.GenerateJson(auditFile);
-            //string xml = gerador.GenerateXml(auditFile);
+            string xml = gerador.GenerateXml(auditFile);
 
             // Gravar o XML num ficheiro
             //File.WriteAllText("saft_mozambique.xml", xml);
@@ -46,15 +46,15 @@ namespace Simansoft.SAFT.Examples.MozambiqueDemo
             //Console.ReadKey(false);
             //Console.WriteLine("=== XML ===");
 
-            //Console.WriteLine(xml);
+            Console.WriteLine(xml);
             Console.WriteLine("Vou criar o ficheiro Excel...");
             Console.ReadKey(true);
 
             byte[] excel = gerador.GenerateBytesExcel(auditFile);
             File.WriteAllBytes("saft_mozambique.xlsx", excel);
 
-            byte[] xml = gerador.GenerateBytesXml(auditFile);            
-            File.WriteAllBytes("saft_mozambique.xml", xml);
+            byte[] xmlByte = gerador.GenerateBytesXml(auditFile);            
+            File.WriteAllBytes("saft_mozambique.xml", xmlByte);
 
             //File.WriteAllText("saft_mozambique.xml", xml);
 

--- a/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
+++ b/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
@@ -161,20 +161,7 @@ namespace Simansoft.SAFT.Mozambique.Generators
                             CustomerID =  doc.Cliente.EConsumidorFinal ? "Consumidor Final" : doc.Cliente.Id,
                             InvoiceType = doc.CategoriaId,
 
-                            //ShipTo = new ShipFromTo{
-                            //    Address = new CustomerAddress
-                            //    {
-                            //        AddressDetail = doc.Cliente.Endereco,
-                            //        City = doc.Cliente.Cidade,
-                            //        PostalCode = doc.Cliente.CodigoPostal,
-                            //        Country = doc.Cliente.Pais
-                            //    }
-                            //},
-                            //ShipFrom = new ShipFromTo
-                            //{
-                            //    Address = new CustomerAddress
-                            //    {
-                            //        AddressDetail = ficheiroSAFT.Empresa.Endereco1,
+                            
                             //        City = ficheiroSAFT.Empresa.Cidade,
                             //        PostalCode = ficheiroSAFT.Empresa.CodigoPostal,
                             //        Country = ficheiroSAFT.Empresa.Pais

--- a/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
+++ b/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
@@ -35,13 +35,13 @@ namespace Simansoft.SAFT.Mozambique.Generators
                                 PostalCode = s.Cliente.CodigoPostal,
                                 Country = s.Cliente.Pais
                             },
-                            ShipToAddress = s.Cliente.EConsumidorFinal ? null : new CustomerAddress
-                            {
-                                AddressDetail = s.Cliente.Endereco,
-                                City = s.Cliente.Cidade,
-                                PostalCode = s.Cliente.CodigoPostal,
-                                Country = s.Cliente.Pais
-                            },
+                            //ShipToAddress = s.Cliente.EConsumidorFinal ? null : new CustomerAddress
+                            //{
+                            //    AddressDetail = s.Cliente.Endereco,
+                            //    City = s.Cliente.Cidade,
+                            //    PostalCode = s.Cliente.CodigoPostal,
+                            //    Country = s.Cliente.Pais
+                            //},
                             SelfBillingIndicator = "0"
                         }).FirstOrDefault()!);
 
@@ -167,25 +167,25 @@ namespace Simansoft.SAFT.Mozambique.Generators
                             CustomerID =  doc.Cliente.EConsumidorFinal ? "Consumidor Final" : doc.Cliente.Id,
                             InvoiceType = doc.CategoriaId,
 
-                            ShipTo = new ShipFromTo{
-                                Address = new CustomerAddress
-                                {
-                                    AddressDetail = doc.Cliente.Endereco,
-                                    City = doc.Cliente.Cidade,
-                                    PostalCode = doc.Cliente.CodigoPostal,
-                                    Country = doc.Cliente.Pais
-                                }
-                            },
-                            ShipFrom = new ShipFromTo
-                            {
-                                Address = new CustomerAddress
-                                {
-                                    AddressDetail = ficheiroSAFT.Empresa.Endereco1,
-                                    City = ficheiroSAFT.Empresa.Cidade,
-                                    PostalCode = ficheiroSAFT.Empresa.CodigoPostal,
-                                    Country = ficheiroSAFT.Empresa.Pais
-                                }
-                            },
+                            //ShipTo = new ShipFromTo{
+                            //    Address = new CustomerAddress
+                            //    {
+                            //        AddressDetail = doc.Cliente.Endereco,
+                            //        City = doc.Cliente.Cidade,
+                            //        PostalCode = doc.Cliente.CodigoPostal,
+                            //        Country = doc.Cliente.Pais
+                            //    }
+                            //},
+                            //ShipFrom = new ShipFromTo
+                            //{
+                            //    Address = new CustomerAddress
+                            //    {
+                            //        AddressDetail = ficheiroSAFT.Empresa.Endereco1,
+                            //        City = ficheiroSAFT.Empresa.Cidade,
+                            //        PostalCode = ficheiroSAFT.Empresa.CodigoPostal,
+                            //        Country = ficheiroSAFT.Empresa.Pais
+                            //    }
+                            //},
 
                             Lines = [.. doc.Artigos.Select((artigo, linhaArtigo) => new InvoiceLine
                             {
@@ -454,29 +454,29 @@ namespace Simansoft.SAFT.Mozambique.Generators
                         writer.WriteEndElement(); // Fecha o elemento BillingAddress
                     }
 
-                    if (customer.ShipToAddress is not null)
-                    {
-                        writer.WriteStartElement(nameof(customer.ShipToAddress)); // Abre o elemento ShipToAddress
-                        if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.AddressDetail))
-                        {
-                            writer.WriteElementString(nameof(customer.ShipToAddress.AddressDetail), TratamentoStringXML(customer.ShipToAddress.AddressDetail));
-                        }
-                        if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.City))
-                        {
-                            writer.WriteElementString(nameof(customer.ShipToAddress.City), TratamentoStringXML(customer.ShipToAddress.City));
-                        }
-                        if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.PostalCode))
-                        {
-                            writer.WriteElementString(nameof(customer.ShipToAddress.PostalCode), TratamentoStringXML(customer.ShipToAddress.PostalCode));
-                        }
+                    //if (customer.ShipToAddress is not null)
+                    //{
+                    //    writer.WriteStartElement(nameof(customer.ShipToAddress)); // Abre o elemento ShipToAddress
+                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.AddressDetail))
+                    //    {
+                    //        writer.WriteElementString(nameof(customer.ShipToAddress.AddressDetail), TratamentoStringXML(customer.ShipToAddress.AddressDetail));
+                    //    }
+                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.City))
+                    //    {
+                    //        writer.WriteElementString(nameof(customer.ShipToAddress.City), TratamentoStringXML(customer.ShipToAddress.City));
+                    //    }
+                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.PostalCode))
+                    //    {
+                    //        writer.WriteElementString(nameof(customer.ShipToAddress.PostalCode), TratamentoStringXML(customer.ShipToAddress.PostalCode));
+                    //    }
 
-                        // Faltando Province
-                        if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.Country))
-                        {
-                            writer.WriteElementString(nameof(customer.ShipToAddress.Country), TratamentoStringXML(customer.ShipToAddress.Country));
-                        }
-                        writer.WriteEndElement(); // Fecha o elemento ShipToAddress
-                    }
+                    //    // Faltando Province
+                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.Country))
+                    //    {
+                    //        writer.WriteElementString(nameof(customer.ShipToAddress.Country), TratamentoStringXML(customer.ShipToAddress.Country));
+                    //    }
+                    //    writer.WriteEndElement(); // Fecha o elemento ShipToAddress
+                    //}
 
 
                     // Faltando Telephone
@@ -569,64 +569,64 @@ namespace Simansoft.SAFT.Mozambique.Generators
                     writer.WriteElementString(nameof(invoice.TransactionID), invoice.TransactionID);
                     writer.WriteElementString(nameof(invoice.CustomerID), invoice.CustomerID);
 
-                    if (invoice.ShipTo is not null)
-                    {
-                        writer.WriteStartElement(nameof(invoice.ShipTo)); // Abre o elemento ShipTo
-                        if (invoice.ShipTo.Address is not null)
-                        {
-                            writer.WriteStartElement(nameof(invoice.ShipTo.Address)); // Abre o elemento Address
+                    //if (invoice.ShipTo is not null)
+                    //{
+                    //    writer.WriteStartElement(nameof(invoice.ShipTo)); // Abre o elemento ShipTo
+                    //    if (invoice.ShipTo.Address is not null)
+                    //    {
+                    //        writer.WriteStartElement(nameof(invoice.ShipTo.Address)); // Abre o elemento Address
 
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.AddressDetail))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipTo.Address.AddressDetail), TratamentoStringXML(invoice.ShipTo?.Address?.AddressDetail));
-                            }
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.City))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipTo.Address.City), TratamentoStringXML(invoice.ShipTo?.Address?.City));
-                            }
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.PostalCode))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipTo.Address.PostalCode), TratamentoStringXML(invoice.ShipTo?.Address?.PostalCode));
-                            }
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.Country))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipTo.Address.Country), TratamentoStringXML(invoice.ShipTo?.Address?.Country));
-                            }
-                            writer.WriteEndElement(); // Fecha o elemento Address
-                        }
-                        writer.WriteEndElement(); // Fecha o elemento ShipTo
-                    }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.AddressDetail))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipTo.Address.AddressDetail), TratamentoStringXML(invoice.ShipTo?.Address?.AddressDetail));
+                    //        }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.City))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipTo.Address.City), TratamentoStringXML(invoice.ShipTo?.Address?.City));
+                    //        }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.PostalCode))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipTo.Address.PostalCode), TratamentoStringXML(invoice.ShipTo?.Address?.PostalCode));
+                    //        }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipTo?.Address?.Country))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipTo.Address.Country), TratamentoStringXML(invoice.ShipTo?.Address?.Country));
+                    //        }
+                    //        writer.WriteEndElement(); // Fecha o elemento Address
+                    //    }
+                    //    writer.WriteEndElement(); // Fecha o elemento ShipTo
+                    //}
 
-                    if (invoice.ShipFrom is not null)
-                    {
-                        writer.WriteStartElement(nameof(invoice.ShipFrom)); // Abre o elemento ShipFrom
-                        if (invoice.ShipFrom.Address is not null)
-                        {
-                            writer.WriteStartElement(nameof(invoice.ShipFrom.Address)); // Abre o elemento Address
+                    //if (invoice.ShipFrom is not null)
+                    //{
+                    //    writer.WriteStartElement(nameof(invoice.ShipFrom)); // Abre o elemento ShipFrom
+                    //    if (invoice.ShipFrom.Address is not null)
+                    //    {
+                    //        writer.WriteStartElement(nameof(invoice.ShipFrom.Address)); // Abre o elemento Address
 
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.AddressDetail))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipFrom.Address.AddressDetail), TratamentoStringXML(invoice.ShipFrom?.Address?.AddressDetail));
-                            }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.AddressDetail))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipFrom.Address.AddressDetail), TratamentoStringXML(invoice.ShipFrom?.Address?.AddressDetail));
+                    //        }
 
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.City))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipFrom.Address.City), TratamentoStringXML(invoice.ShipFrom?.Address?.City));
-                            }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.City))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipFrom.Address.City), TratamentoStringXML(invoice.ShipFrom?.Address?.City));
+                    //        }
 
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.PostalCode))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipFrom.Address.PostalCode), TratamentoStringXML(invoice.ShipFrom?.Address?.PostalCode));
-                            }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.PostalCode))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipFrom.Address.PostalCode), TratamentoStringXML(invoice.ShipFrom?.Address?.PostalCode));
+                    //        }
 
-                            if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.Country))
-                            {
-                                writer.WriteElementString(nameof(invoice.ShipFrom.Address.Country), TratamentoStringXML(invoice.ShipFrom?.Address?.Country));
-                            }
-                            writer.WriteEndElement(); // Fecha o elemento Address
-                        }
-                        writer.WriteEndElement(); // Fecha o elemento ShipFrom
-                    }
+                    //        if (!string.IsNullOrWhiteSpace(invoice.ShipFrom?.Address?.Country))
+                    //        {
+                    //            writer.WriteElementString(nameof(invoice.ShipFrom.Address.Country), TratamentoStringXML(invoice.ShipFrom?.Address?.Country));
+                    //        }
+                    //        writer.WriteEndElement(); // Fecha o elemento Address
+                    //    }
+                    //    writer.WriteEndElement(); // Fecha o elemento ShipFrom
+                    //}
 
                     invoice.Lines!.ForEach(artigo =>
                     {

--- a/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
+++ b/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
@@ -35,13 +35,7 @@ namespace Simansoft.SAFT.Mozambique.Generators
                                 PostalCode = s.Cliente.CodigoPostal,
                                 Country = s.Cliente.Pais
                             },
-                            //ShipToAddress = s.Cliente.EConsumidorFinal ? null : new CustomerAddress
-                            //{
-                            //    AddressDetail = s.Cliente.Endereco,
-                            //    City = s.Cliente.Cidade,
-                            //    PostalCode = s.Cliente.CodigoPostal,
-                            //    Country = s.Cliente.Pais
-                            //},
+// Removed commented-out ShipToAddress block to clean up the code.
                             SelfBillingIndicator = "0"
                         }).FirstOrDefault()!);
 

--- a/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
+++ b/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
@@ -435,31 +435,7 @@ namespace Simansoft.SAFT.Mozambique.Generators
                         writer.WriteEndElement(); // Fecha o elemento BillingAddress
                     }
 
-                    //if (customer.ShipToAddress is not null)
-                    //{
-                    //    writer.WriteStartElement(nameof(customer.ShipToAddress)); // Abre o elemento ShipToAddress
-                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.AddressDetail))
-                    //    {
-                    //        writer.WriteElementString(nameof(customer.ShipToAddress.AddressDetail), TratamentoStringXML(customer.ShipToAddress.AddressDetail));
-                    //    }
-                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.City))
-                    //    {
-                    //        writer.WriteElementString(nameof(customer.ShipToAddress.City), TratamentoStringXML(customer.ShipToAddress.City));
-                    //    }
-                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.PostalCode))
-                    //    {
-                    //        writer.WriteElementString(nameof(customer.ShipToAddress.PostalCode), TratamentoStringXML(customer.ShipToAddress.PostalCode));
-                    //    }
-
-                    //    // Faltando Province
-                    //    if (!string.IsNullOrWhiteSpace(customer.ShipToAddress.Country))
-                    //    {
-                    //        writer.WriteElementString(nameof(customer.ShipToAddress.Country), TratamentoStringXML(customer.ShipToAddress.Country));
-                    //    }
-                    //    writer.WriteEndElement(); // Fecha o elemento ShipToAddress
-                    //}
-
-
+// Removed commented-out block for ShipToAddress to improve code readability and maintainability.
                     // Faltando Telephone
                     // Faltando Fax
                     // Faltando Email


### PR DESCRIPTION
Ativa a geração e exibição de arquivos XML no `BasicMozDemo.cs`, enquanto o código para JSON foi comentado. Renomeia a variável de bytes XML para `xmlByte` para maior clareza.

No `MozambiqueSaftGenerator.cs`, desativa a lógica relacionada a endereços de envio (`ShipToAddress` e `ShipFrom`), simplificando a geração do arquivo. A verificação de nulidade para esses endereços também foi comentada, removendo temporariamente essa funcionalidade.

Essas mudanças visam simplificar o código, mantendo a geração de XML e Excel.