### PR TITLE
Arredondamento de valores financeiros em SAFT

### DIFF
--- a/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
+++ b/src/SAF-T.Mozambique/Generators/MozambiqueSaftGenerator.cs
@@ -78,8 +78,8 @@ namespace Simansoft.SAFT.Mozambique.Generators
                             TaxCountryRegion = s.Pais,
                             TaxCode = s.Codigo,
                             Description = s.Descricao,
-                            TaxPercentage = s.Percentagem,
-                            TaxAmount = s.Valor
+                            TaxPercentage = Math.Round(s.Percentagem, 2),
+                            TaxAmount = Math.Round(s.Valor, 2)
                         }).FirstOrDefault()!);
             });
 
@@ -130,8 +130,8 @@ namespace Simansoft.SAFT.Mozambique.Generators
                     SalesInvoices = new SalesInvoices()
                     {
                         NumberOfEntries = ficheiroSAFT.DocumentosFacturacao.Count,
-                        TotalDebit = ficheiroSAFT.TotalDebito,
-                        TotalCredit = ficheiroSAFT.TotalCredito,
+                        TotalDebit = Math.Round(ficheiroSAFT.TotalDebito, 2),
+                        TotalCredit = Math.Round(ficheiroSAFT.TotalCredito, 2),
                         Invoices = [.. ficheiroSAFT.DocumentosFacturacao.Select(doc => new Invoice
                         {
                             InvoiceNo = doc.Id,
@@ -177,12 +177,12 @@ namespace Simansoft.SAFT.Mozambique.Generators
                                 ProductDescription = artigo.Artigo.Descricao,
                                 Quantity = artigo.Quantidade,
                                 UnitOfMeasure = artigo.Artigo.UnidadeContagem,
-                                UnitPrice = artigo.PrecoUnitarioSemImpostos,
-                                TaxBase = artigo.PrecoTotalSemImpostos,
+                                UnitPrice = Math.Round(artigo.PrecoUnitarioSemImpostos, 2),
+                                TaxBase = Math.Round(artigo.PrecoTotalSemImpostos, 2),
                                 TaxPointDate = doc.DataHora,
                                 Description = artigo.ArtigoDescricao,
-                                DebitAmount = artigo.PrecoTotalComImpostos < 0 ? -artigo.PrecoTotalComImpostos : 0m,
-                                CreditAmount = artigo.PrecoTotalComImpostos > 0 ? artigo.PrecoTotalComImpostos : 0m,
+                                DebitAmount = Math.Round(artigo.PrecoTotalComImpostos < 0 ? -artigo.PrecoTotalComImpostos : 0m, 2),
+                                CreditAmount = Math.Round(artigo.PrecoTotalComImpostos > 0 ? artigo.PrecoTotalComImpostos : 0m, 2),
 
                                 SettlementAmount = artigo.ValorDesconto,
 
@@ -191,8 +191,8 @@ namespace Simansoft.SAFT.Mozambique.Generators
                                     TaxType = imp.Tipo,
                                     TaxCountryRegion = imp.Pais,
                                     TaxCode = imp.Codigo,
-                                    TaxPercentage = imp.Percentagem,
-                                    TaxAmount = imp.Valor + (artigo.PrecoTotalComImpostos / (1m + (imp.Percentagem * 0.01m))) * (imp.Percentagem * 0.01m)
+                                    TaxPercentage = Math.Round(imp.Percentagem, 2),
+                                    TaxAmount = Math.Round(imp.Valor + (artigo.PrecoTotalComImpostos / (1m + (imp.Percentagem * 0.01m))) * (imp.Percentagem * 0.01m), 2)
                                 })],
 
                                 TaxExemptionReason = artigo.Artigo.Motivo,
@@ -200,13 +200,13 @@ namespace Simansoft.SAFT.Mozambique.Generators
                             })],
                             DocumentTotals = new DocumentTotals
                             {
-                                TaxPayable = doc.Artigos.Sum(s => s.PrecoTotalSemImpostos),
-                                NetTotal = doc.Artigos.Sum(s => s.ValorImpostos),
-                                GrossTotal = doc.Artigos.Sum(s => s.PrecoTotalComImpostos),
+                                TaxPayable = Math.Round(doc.Artigos.Sum(s => s.PrecoTotalSemImpostos), 2),
+                                NetTotal = Math.Round(doc.Artigos.Sum(s => s.ValorImpostos), 2),
+                                GrossTotal = Math.Round(doc.Artigos.Sum(s => s.PrecoTotalComImpostos), 2),
                                 Payments = [.. doc.MeiosPagamento.Select(p => new Payment
                                 {
                                     PaymentMechanism = p.TipoId,
-                                    PaymentAmount = p.Valor,
+                                    PaymentAmount = Math.Round(p.Valor, 2),
                                     PaymentDate = p.Data
                                 })]
                             }


### PR DESCRIPTION
Melhora a precisão dos cálculos financeiros no arquivo `MozambiqueSaftGenerator.cs` ao adicionar arredondamento para duas casas decimais em campos como `TaxPercentage`, `TaxAmount`, `TotalDebit`, `TotalCredit`, `UnitPrice`, `TaxBase`, `DebitAmount`, `CreditAmount`, `TaxPayable`, `NetTotal` e `GrossTotal`.