### PR TITLE
Corrige divisões por zero em cálculos de preços

### DIFF
--- a/src/SAF-T.Mozambique/Models/FicheiroSAFT.cs
+++ b/src/SAF-T.Mozambique/Models/FicheiroSAFT.cs
@@ -191,11 +191,11 @@ namespace Simansoft.SAFT.Mozambique.Models
         public decimal Quantidade { get; init; }
         public decimal PrecoTotalComImpostos { get; init; }
         public decimal ValorDesconto { get; init; }
-        public decimal PercentagemDesconto { get => ValorDesconto / PrecoTotalComImpostos * 100; }
+        public decimal PercentagemDesconto { get => PrecoTotalComImpostos == 0m ? 0m : ValorDesconto / PrecoTotalComImpostos * 100; }
         public decimal ValorImpostos { get => Artigo.Impostos.Sum(i => i.Valor + (PrecoTotalComImpostos / (1m + i.Percentagem * 0.01m) * i.Percentagem * 0.01m)); }
         public decimal PrecoTotalSemImpostos { get => PrecoTotalComImpostos - ValorImpostos; }
-        public decimal PrecoUnitarioComImpostos { get => (PrecoTotalComImpostos + ValorDesconto) / Quantidade; }
-        public decimal PrecoUnitarioSemImpostos { get => PrecoUnitarioComImpostos - (ValorImpostos / Quantidade); }
+        public decimal PrecoUnitarioComImpostos { get => Quantidade == 0m ? 0m : (PrecoTotalComImpostos + ValorDesconto) / Quantidade; }
+        public decimal PrecoUnitarioSemImpostos { get => Quantidade == 0m ? 0m : PrecoUnitarioComImpostos - (ValorImpostos / Quantidade); }
 
     }
 


### PR DESCRIPTION
A lógica de cálculo da propriedade `PercentagemDesconto` foi ajustada para evitar divisão por zero, retornando 0m quando `PrecoTotalComImpostos` é zero.

As propriedades `PrecoUnitarioComImpostos` e `PrecoUnitarioSemImpostos` também foram modificadas para retornar 0m quando `Quantidade` é zero, prevenindo assim exceções de divisão por zero.