### PR TITLE
Adicionado o campo de moeda

### DIFF
--- a/src/SAF-T.Mozambique/Models/FicheiroSAFT.cs
+++ b/src/SAF-T.Mozambique/Models/FicheiroSAFT.cs
@@ -142,6 +142,7 @@ namespace Simansoft.SAFT.Mozambique.Models
 
         public bool? ControlaAssinatura { get; init; }
         public string? Assinatura { get; init; }
+        public string? Moeda { get; init; } = "MZn";
 
         public DateTime DataHora { get; init; }
         public int PeriodoMes { get => DataEmissao.Month; }

--- a/src/SAF-T.Mozambique/Models/FicheiroSAFT.cs
+++ b/src/SAF-T.Mozambique/Models/FicheiroSAFT.cs
@@ -142,7 +142,7 @@ namespace Simansoft.SAFT.Mozambique.Models
 
         public bool? ControlaAssinatura { get; init; }
         public string? Assinatura { get; init; }
-        public string? Moeda { get; init; } = "MZn";
+        public string? Moeda { get; init; } = "MZN";
 
         public DateTime DataHora { get; init; }
         public int PeriodoMes { get => DataEmissao.Month; }


### PR DESCRIPTION
This pull request introduces a minor change to the `FicheiroSAFT` model by adding a default currency property. The new property ensures that the currency value is set to "MZn" unless specified otherwise.